### PR TITLE
Add basic unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,15 @@ To learn more about Next.js, take a look at the following resources:
 
 You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
 
+## Running tests
+
+This project uses [Vitest](https://vitest.dev/) for unit testing. To execute the
+test suite run:
+
+```bash
+npm test
+```
+
 ## Deploy on Vercel
 
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "seed": "ts-node prisma/seed.ts"
+    "seed": "ts-node prisma/seed.ts",
+    "test": "vitest"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",
@@ -40,6 +41,7 @@
     "eslint-config-next": "15.3.2",
     "ts-node": "^10.9.2",
     "tsx": "^4.19.4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^1.4.0"
   }
 }

--- a/tests/pet.test.ts
+++ b/tests/pet.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/shared/prisma", () => {
+  return {
+    prisma: {
+      pet: {
+        create: vi.fn(async (args) => ({ id: "new_id", ...args.data })),
+        update: vi.fn(async (args) => ({ id: args.where.id, ...args.data })),
+      },
+    },
+  };
+});
+
+vi.mock("@/utils/getCurrentUserId", () => {
+  return { getCurrentUserId: vi.fn(async () => "user1") };
+});
+
+import { savePet } from "@/lib/pet/savePet";
+import { prisma } from "@/shared/prisma";
+
+describe("savePet", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates new pet when id not provided", async () => {
+    const result = await savePet({ name: "Rex", type: "DOG" });
+    expect(prisma.pet.create).toHaveBeenCalled();
+    expect(result).toMatchObject({ name: "Rex", type: "DOG" });
+  });
+
+  it("updates pet when id provided", async () => {
+    const result = await savePet({ id: "123", name: "Max", type: "DOG" });
+    expect(prisma.pet.update).toHaveBeenCalledWith({
+      where: { id: "123" },
+      data: expect.any(Object),
+    });
+    expect(result).toMatchObject({ id: "123", name: "Max" });
+  });
+});

--- a/tests/user.test.ts
+++ b/tests/user.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/shared/prisma", () => {
+  return {
+    prisma: {
+      userProfile: {
+        findUnique: vi.fn(async ({ where }) => ({ id: "p1", userId: where.userId })),
+        update: vi.fn(async ({ data }) => ({ id: "p1", ...data })),
+      },
+    },
+  };
+});
+
+vi.mock("@/utils/getCurrentUserId", () => {
+  return { getCurrentUserId: vi.fn(async () => "user1") };
+});
+
+import { getUserProfile } from "@/lib/user/getUserProfile";
+import { updateUserProfile } from "@/lib/user/updateUserProfile";
+import { prisma } from "@/shared/prisma";
+
+describe("user profile", () => {
+  it("gets profile", async () => {
+    const profile = await getUserProfile();
+    expect(prisma.userProfile.findUnique).toHaveBeenCalled();
+    expect(profile).toMatchObject({ userId: "user1" });
+  });
+
+  it("updates profile", async () => {
+    const updated = await updateUserProfile({
+      fullName: "Test User",
+      about: "about",
+      telegram: "tg",
+      instagram: "ig",
+      website: "site",
+      birthDate: "2024-01-01",
+    });
+    expect(prisma.userProfile.update).toHaveBeenCalled();
+    expect(updated.fullName).toBe("Test User");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vitest/config";
+import { resolve } from "path";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": resolve(__dirname, "src"),
+      "@/shared/prisma": resolve(__dirname, "shared/prisma"),
+    },
+  },
+  test: {
+    environment: "node",
+    globals: true,
+  },
+});


### PR DESCRIPTION
## Summary
- set up Vitest configuration
- add unit tests for pet and user helpers
- document testing in README
- add Vitest dev dependency and npm test script

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a143952248326a14d7f2935eade06