### PR TITLE
Add basic unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,15 @@ To learn more about Next.js, take a look at the following resources:
 
 You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
 
+## Running tests
+
+This project uses [Vitest](https://vitest.dev/) for unit testing. To execute the
+test suite run:
+
+```bash
+npm test
+```
+
 ## Deploy on Vercel
 
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "seed": "ts-node prisma/seed.ts"
+    "seed": "ts-node prisma/seed.ts",
+    "test": "vitest"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",
@@ -40,6 +41,7 @@
     "eslint-config-next": "15.3.2",
     "ts-node": "^10.9.2",
     "tsx": "^4.19.4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^1.4.0"
   }
 }

--- a/src/lib/pet/savePet.ts
+++ b/src/lib/pet/savePet.ts
@@ -3,6 +3,7 @@
 
 import { prisma } from "@/shared/prisma";
 import { getCurrentUserId } from "@/utils/getCurrentUserId";
+import { validatePetInput } from "@/utils/validate";
 
 interface UpdatePetInput {
   id?: string;
@@ -32,6 +33,14 @@ export async function savePet({
     if (!id && !ownerId) {
       throw new Error("Поле ownerId обязательно при создании");
     }
+
+    validatePetInput({
+      name,
+      type,
+      birthDate,
+      heightCm,
+      weightKg,
+    });
 
     const parsedDate =
       birthDate && birthDate !== "" ? new Date(birthDate) : null;

--- a/src/lib/user/updateUserProfile.ts
+++ b/src/lib/user/updateUserProfile.ts
@@ -3,6 +3,7 @@
 
 import { prisma } from "@/shared/prisma";
 import { getCurrentUserId } from "@/utils/getCurrentUserId";
+import { validateProfileInput } from "@/utils/validate";
 
 interface UpdateUserProfileInput {
   fullName: string;
@@ -24,6 +25,15 @@ export async function updateUserProfile({
   try {
     const userId = await getCurrentUserId();
 
+    validateProfileInput({
+      fullName,
+      about,
+      telegram,
+      instagram,
+      website,
+      birthDate,
+    });
+
     const data: any = {
       fullName: fullName || null,
       about: about || null,
@@ -32,15 +42,13 @@ export async function updateUserProfile({
       website: website || null,
     };
 
-    if (birthDate !== undefined) {
-      if (birthDate === "") {
-        data.birthDate = null;
-      } else {
-        const parsed = new Date(birthDate);
-        if (isNaN(parsed.getTime())) throw new Error("Неверная дата");
-        data.birthDate = parsed;
-      }
+  if (birthDate !== undefined) {
+    if (birthDate === "") {
+      data.birthDate = null;
+    } else {
+      data.birthDate = new Date(birthDate);
     }
+  }
 
     return await prisma.userProfile.update({
       where: { userId },

--- a/src/utils/validate.ts
+++ b/src/utils/validate.ts
@@ -1,0 +1,83 @@
+export function validatePetInput(input: {
+  name: string;
+  type: string;
+  birthDate?: string;
+  heightCm?: number;
+  weightKg?: number;
+}) {
+  if (!input.name || input.name.trim() === "") {
+    throw new Error("Имя питомца обязательно");
+  }
+
+  if (!["DOG", "CAT"].includes(input.type)) {
+    throw new Error("Неизвестный тип питомца");
+  }
+
+  if (input.birthDate && input.birthDate !== "") {
+    const date = new Date(input.birthDate);
+    if (isNaN(date.getTime())) {
+      throw new Error("Некорректная дата рождения");
+    }
+    if (date > new Date()) {
+      throw new Error("Дата рождения не может быть в будущем");
+    }
+  }
+
+  if (input.heightCm != null) {
+    if (typeof input.heightCm !== "number" || input.heightCm <= 0) {
+      throw new Error("Рост должен быть положительным числом");
+    }
+  }
+
+  if (input.weightKg != null) {
+    if (typeof input.weightKg !== "number" || input.weightKg <= 0) {
+      throw new Error("Вес должен быть положительным числом");
+    }
+  }
+}
+
+export function validateProfileInput(input: {
+  fullName: string;
+  about: string;
+  telegram: string;
+  instagram: string;
+  website: string;
+  birthDate: string;
+}) {
+  if (input.fullName && input.fullName.trim() !== "") {
+    if (!/^[A-Za-zА-Яа-яЁё\s-]{2,60}$/.test(input.fullName)) {
+      throw new Error("Некорректное имя пользователя");
+    }
+  }
+
+  if (input.telegram) {
+    if (!/^[a-zA-Z0-9_]{5,32}$/.test(input.telegram)) {
+      throw new Error("Некорректный Telegram username");
+    }
+  }
+
+  if (input.instagram) {
+    if (!/^[a-zA-Z0-9_.]{2,50}$/.test(input.instagram)) {
+      throw new Error("Некорректный Instagram username");
+    }
+  }
+
+  if (input.website) {
+    try {
+      new URL(input.website);
+    } catch {
+      throw new Error("Некорректный URL сайта");
+    }
+  }
+
+  if (input.birthDate !== undefined) {
+    if (input.birthDate === "") return;
+    const date = new Date(input.birthDate);
+    if (isNaN(date.getTime())) {
+      throw new Error("Неверная дата");
+    }
+    if (date > new Date()) {
+      throw new Error("Дата не может быть в будущем");
+    }
+  }
+}

--- a/tests/pet.test.ts
+++ b/tests/pet.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/shared/prisma", () => {
+  return {
+    prisma: {
+      pet: {
+        create: vi.fn(async (args) => ({ id: "new_id", ...args.data })),
+        update: vi.fn(async (args) => ({ id: args.where.id, ...args.data })),
+      },
+    },
+  };
+});
+
+vi.mock("@/utils/getCurrentUserId", () => {
+  return { getCurrentUserId: vi.fn(async () => "user1") };
+});
+
+import { savePet } from "@/lib/pet/savePet";
+import { prisma } from "@/shared/prisma";
+
+describe("savePet", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates new pet when id not provided", async () => {
+    const result = await savePet({ name: "Rex", type: "DOG" });
+    expect(prisma.pet.create).toHaveBeenCalled();
+    expect(result).toMatchObject({ name: "Rex", type: "DOG" });
+  });
+
+  it("updates pet when id provided", async () => {
+    const result = await savePet({ id: "123", name: "Max", type: "DOG" });
+    expect(prisma.pet.update).toHaveBeenCalledWith({
+      where: { id: "123" },
+      data: expect.any(Object),
+    });
+    expect(result).toMatchObject({ id: "123", name: "Max" });
+  });
+});

--- a/tests/user.test.ts
+++ b/tests/user.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/shared/prisma", () => {
+  return {
+    prisma: {
+      userProfile: {
+        findUnique: vi.fn(async ({ where }) => ({ id: "p1", userId: where.userId })),
+        update: vi.fn(async ({ data }) => ({ id: "p1", ...data })),
+      },
+    },
+  };
+});
+
+vi.mock("@/utils/getCurrentUserId", () => {
+  return { getCurrentUserId: vi.fn(async () => "user1") };
+});
+
+import { getUserProfile } from "@/lib/user/getUserProfile";
+import { updateUserProfile } from "@/lib/user/updateUserProfile";
+import { prisma } from "@/shared/prisma";
+
+describe("user profile", () => {
+  it("gets profile", async () => {
+    const profile = await getUserProfile();
+    expect(prisma.userProfile.findUnique).toHaveBeenCalled();
+    expect(profile).toMatchObject({ userId: "user1" });
+  });
+
+  it("updates profile", async () => {
+    const updated = await updateUserProfile({
+      fullName: "Test User",
+      about: "about",
+      telegram: "tguser",
+      instagram: "igacc",
+      website: "http://example.com",
+      birthDate: "2024-01-01",
+    });
+    expect(prisma.userProfile.update).toHaveBeenCalled();
+    expect(updated.fullName).toBe("Test User");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vitest/config";
+import { resolve } from "path";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": resolve(__dirname, "src"),
+      "@/shared/prisma": resolve(__dirname, "shared/prisma"),
+    },
+  },
+  test: {
+    environment: "node",
+    globals: true,
+  },
+});


### PR DESCRIPTION
## Summary
- set up Vitest configuration
- add unit tests for pet and user helpers
- document testing in README
- add Vitest dev dependency and npm test script
- improve server-side validation for profile and pet functions

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a143952248326a14d7f2935eade06